### PR TITLE
Added hook for better text display in IE

### DIFF
--- a/src/jquery.infieldlabel.js
+++ b/src/jquery.infieldlabel.js
@@ -65,7 +65,9 @@
     };
 
     base.setOpacity = function (opacity) {
-      base.$label.stop().animate({ opacity: opacity }, base.options.fadeDuration);
+      base.$label.stop().animate({ opacity: opacity }, base.options.fadeDuration, function(){
+          if ($.browser.msie){this.style.removeAttribute('filter');}
+      });
       base.showing = (opacity > 0.0);
     };
 


### PR DESCRIPTION
Added hook into setOpacity function to remove filter from element in IE. This gets rid of the ugly jagged text after the fade runs. This is especially noticeable when using custom fonts.
