### PR TITLE
Allows a descendant of the label to be used in-field and faded.

### DIFF
--- a/src/jquery.infieldlabel.js
+++ b/src/jquery.infieldlabel.js
@@ -125,7 +125,8 @@
       // Find input or textarea based on for= attribute
       // The for attribute on the label must contain the ID
       // of the input or textarea element
-      var for_attr = $(this).attr('for'), $field;
+      var label = this.tagName==='label' ? $(this) : $(this).parent('label[for]');
+      var for_attr = label.attr('for'), $field;
       if (!for_attr) {
         return; // Nothing to attach, since the for field wasn't used
       }


### PR DESCRIPTION
Consider this use case:

&lt;label for="foo"&gt;
  &lt;img src="required.gif" alt="This field is required" /&gt;
  &lt;span&gt;Bar&lt;/span&gt;
&lt;/label&gt;
&lt;input id="foo" type="text" name="baz" /&gt;

$('label span').inFieldLabels();

It's not desirable to have the image fade also, but it is desirable to include it as part of the label for accessibility and semantic reasons.
