### PR TITLE
explicitly add empty placeholder to inputs, fix browser issue

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -29,7 +29,7 @@ h3. HTML
 <pre>
 <p>
   <label for="field_id">Label Text</label><br />
-  <input type="text" name="field_id" value="" id="field_id">
+  <input type="text" name="field_id" value="" id="field_id" placeholder="">
 </p>
 </pre>
 

--- a/sample/index.html
+++ b/sample/index.html
@@ -45,19 +45,19 @@
 			<legend>Comment Form</legend>
 			<p>
 				<label for="name">Name</label><br />
-				<input type="text" name="name" value="" id="name">
+				<input type="text" name="name" value="" id="name" placeholder="">
 			</p>
 			<p>
 				<label for="email">Email</label><br />
-				<input type="text" name="email" value="" id="email">
+				<input type="text" name="email" value="" id="email" placeholder="">
 			</p>
 			<p>
 				<label for="website">Website</label><br />
-				<input type="text" name="website" value="" id="website">
+				<input type="text" name="website" value="" id="website" placeholder="">
 			</p>
 			<p>
 				<label for="comment">Comment</label><br />
-				<textarea cols="30" rows="10" name="comment" id="comment"></textarea>
+				<textarea cols="30" rows="10" name="comment" id="comment" placeholder=""></textarea>
 			</p>
 		</fieldset>
 		<p><input type="submit" value="Continue &rarr;"></p>
@@ -68,11 +68,11 @@
 			<legend>Login Form</legend>
 			<p>
 				<label for="username">Username</label><br />
-				<input type="text" name="username" value="" id="username">
+				<input type="text" name="username" value="" id="username" placeholder="">
 			</p>
 			<p>
 				<label for="password">Password</label><br />
-				<input type="password" name="password" value="" id="password">
+				<input type="password" name="password" value="" id="password" placeholder="">
 			</p>
 		</fieldset>
 		<p><input type="submit" value="Continue &rarr;"></p>


### PR DESCRIPTION
Fixes an issue where browsers would insert »UNKNOWN_TYPE« as placeholder for some reason. See https://github.com/owncloud/core/issues/2049

cc @dcneiner
